### PR TITLE
fix(ui): improve filter selection tap area in ExpenseFiltersView

### DIFF
--- a/ReceiptScannerExpenseTracker/ReceiptScannerExpenseTracker/Views/ExpenseFiltersView.swift
+++ b/ReceiptScannerExpenseTracker/ReceiptScannerExpenseTracker/Views/ExpenseFiltersView.swift
@@ -293,6 +293,8 @@ struct CategoryFilterRow: View {
                 }
             }
             .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
@@ -322,6 +324,8 @@ struct DateRangeFilterRow: View {
                 }
             }
             .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
@@ -351,6 +355,8 @@ struct AmountRangeFilterRow: View {
                 }
             }
             .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
@@ -380,6 +386,8 @@ struct VendorFilterRow: View {
                 }
             }
             .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])


### PR DESCRIPTION
- Add contentShape(Rectangle()) to make entire filter row tappable
- Add horizontal padding for better visual spacing
- Apply fix to all filter types: categories, tags, date ranges, and amount ranges
- Users can now tap anywhere in the filter row to select/deselect options

Improves UX by expanding the tap target area beyond just the text content.